### PR TITLE
makes the exception handling closer to Promises/A+ specification

### DIFF
--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -12,56 +12,51 @@ use Promises::Promise;
 use constant IN_PROGRESS => 'in progress';
 use constant RESOLVED    => 'resolved';
 use constant REJECTED    => 'rejected';
-use constant RESOLVING   => 'resolving';
-use constant REJECTING   => 'rejecting';
 
 sub new {
     my $class = shift;
-    my $self  = bless {
+    bless {
         resolved => [],
         rejected => [],
         status   => IN_PROGRESS,
-        promise  => undef
     } => $class;
-    $self->{'promise'} = Promises::Promise->new( $self );
-    $self;
 }
 
-sub promise { (shift)->{'promise'} }
+sub promise { Promises::Promise->new(shift) }
 sub status  { (shift)->{'status'}  }
 sub result  { (shift)->{'result'}  }
 
 # predicates for all the status possiblities
 sub is_in_progress { (shift)->{'status'} eq IN_PROGRESS }
-sub is_resolving   { (shift)->{'status'} eq RESOLVING   }
-sub is_rejecting   { (shift)->{'status'} eq REJECTING   }
 sub is_resolved    { (shift)->{'status'} eq RESOLVED    }
 sub is_rejected    { (shift)->{'status'} eq REJECTED    }
 
 # the three possible states according to the spec ...
 sub is_unfulfilled { (shift)->is_in_progress            }
-sub is_fulfilled   { $_[0]->is_resolved || $_[0]->is_resolving }
-sub is_failed      { $_[0]->is_rejected || $_[0]->is_rejecting }
+sub is_fulfilled   { $_[0]->is_resolved  }
+sub is_failed      { $_[0]->is_rejected  }
 
 sub resolve {
     my $self   = shift;
-    my $result = [ @_ ];
-    $self->{'result'} = $result;
-    $self->{'status'} = RESOLVING;
-    $self->_notify( $self->{'resolved'}, $result );
-    $self->{'resolved'} = [];
+
+    # return or die ?
+    $self->is_in_progress or return;
+    
+    $self->{'result'} = [ @_ ];
     $self->{'status'}   = RESOLVED;
+    $self->_notify;
     $self;
 }
 
 sub reject {
     my $self = shift;
-    my $result = [ @_ ];
-    $self->{'result'} = $result;
-    $self->{'status'} = REJECTING;
-    $self->_notify( $self->{'rejected'}, $result );
-    $self->{'rejected'} = [];
+
+    # return or die ?
+    $self->is_in_progress or return;
+
+    $self->{'result'} = [ @_ ];
     $self->{'status'}   = REJECTED;
+    $self->_notify;
     $self;
 }
 
@@ -69,52 +64,54 @@ sub then {
     my ($self, $callback, $error) = @_;
 
     (ref $callback && reftype $callback eq 'CODE')
-        || confess "You must pass in a success callback";
+        || confess "You must pass in a success callback"
+	   if $callback;
 
     (ref $error && reftype $error eq 'CODE')
         || confess "You must pass in a error callback"
             if $error;
 
-    # if we don't get an error
-    # handler, we need to chain
-    # it automatically
-    $error ||= sub { @_ };
+    # no default error handler
 
     my $d = (ref $self)->new;
 
     push @{ $self->{'resolved'} } => $self->_wrap( $d, $callback, 'resolve' );
     push @{ $self->{'rejected'} } => $self->_wrap( $d, $error,    'reject'  );
 
-    if ( $self->status eq RESOLVED ) {
-        $self->resolve( @{ $self->result } );
-    }
-
-    if ( $self->status eq REJECTED ) {
-        $self->reject( @{ $self->result } );
-    }
+    $self->_notify if !$self->is_in_progress;
 
     $d->promise;
 }
 
 sub _wrap {
     my ($self, $d, $f, $method) = @_;
-    return sub {
-        my @results = $f->( @_ );
-        if ( (scalar @results) == 1 && blessed $results[0] && $results[0]->isa('Promises::Promise') ) {
+    return $f? sub {
+        my @results = eval { $f->( @_ ) };
+	if (my $err = $@){
+	    $d->reject($err);
+	}
+        elsif ( (scalar @results) == 1 && blessed $results[0] && $results[0]->isa('Promises::Promise') ) {
             $results[0]->then(
-                sub { $d->resolve( @{ $results[0]->result } ) },
-                sub { $d->reject( @{ $results[0]->result } )  },
+                sub { $d->resolve( @_ ) },
+                sub { $d->reject( @_ )  },
             );
         }
         else {
-            $d->$method( @results )
+            $d->resolve( @results )
         }
-    }
+    }: sub { $d->$method( @_ ) };
 }
 
 sub _notify {
-    my ($self, $callbacks, $result) = @_;
-    $_->( @$result ) foreach @$callbacks;
+    my ( $self ) = @_;
+
+    my $result = $self->result;
+    # cleaning both
+    my @resolved = splice @{$self->{resolved}};
+    my @rejected = splice @{$self->{rejected}};
+    for my $cb ( $self->is_resolved? @resolved: @rejected ) {
+        $cb->(@$result);
+    }
 }
 
 1;

--- a/lib/Promises/Promise.pm
+++ b/lib/Promises/Promise.pm
@@ -23,8 +23,6 @@ sub is_fulfilled   { (shift)->{'deferred'}->is_fulfilled   }
 sub is_failed      { (shift)->{'deferred'}->is_failed      }
 
 sub is_in_progress { (shift)->{'deferred'}->is_in_progress }
-sub is_resolving   { (shift)->{'deferred'}->is_resolving   }
-sub is_rejecting   { (shift)->{'deferred'}->is_rejecting   }
 sub is_resolved    { (shift)->{'deferred'}->is_resolved    }
 sub is_rejected    { (shift)->{'deferred'}->is_rejected    }
 

--- a/t/001-basic.t
+++ b/t/001-basic.t
@@ -30,7 +30,7 @@ is_deeply(
     [
         'ZERO',
         'resolved after 1',
-        Promises::Deferred->RESOLVING,
+        Promises::Deferred->RESOLVED,
         [ 'resolved after 1' ]
     ],
     '... got the expected values back'

--- a/t/002-multiples.t
+++ b/t/002-multiples.t
@@ -39,7 +39,7 @@ is_deeply(
     [
         'ZERO',
         'resolved after 1',
-        Promises::Deferred->RESOLVING,
+        Promises::Deferred->RESOLVED,
         [ 'resolved after 1' ]
     ],
     '... got the expected values back'
@@ -52,7 +52,7 @@ is_deeply(
     [
         'ONE',
         'resolved after 2',
-        Promises::Deferred->RESOLVING,
+        Promises::Deferred->RESOLVED,
         [ 'resolved after 2' ]
     ],
     '... got the expected values back'

--- a/t/003-post-resolve-then.t
+++ b/t/003-post-resolve-then.t
@@ -32,7 +32,7 @@ is_deeply(
     [
         'ZERO',
         'resolved after 1',
-        Promises::Deferred->RESOLVING,
+        Promises::Deferred->RESOLVED,
         [ 'resolved after 1' ]
     ],
     '... got the expected values back'
@@ -50,7 +50,7 @@ is_deeply(
     [
         'ONE',
         'resolved after 1',
-        Promises::Deferred->RESOLVING,
+        Promises::Deferred->RESOLVED,
         [ 'resolved after 1' ]
     ],
     '... got the expected values back'

--- a/t/004-error.t
+++ b/t/004-error.t
@@ -30,7 +30,7 @@ is_deeply(
     [
         'ERROR',
         'rejected after 1',
-        Promises::Deferred->REJECTING,
+        Promises::Deferred->REJECTED,
         [ 'rejected after 1' ]
     ],
     '... got the expected values back'

--- a/t/005-multiples-w-error.t
+++ b/t/005-multiples-w-error.t
@@ -39,7 +39,7 @@ is_deeply(
     [
         'ERROR',
         'rejected after 1',
-        Promises::Deferred->REJECTING,
+        Promises::Deferred->REJECTED,
         [ 'rejected after 1' ]
     ],
     '... got the expected values back'
@@ -52,7 +52,7 @@ is_deeply(
     [
         'ONE',
         'resolved after 2',
-        Promises::Deferred->RESOLVING,
+        Promises::Deferred->RESOLVED,
         [ 'resolved after 2' ]
     ],
     '... got the expected values back'

--- a/t/021-chaining-errors.t
+++ b/t/021-chaining-errors.t
@@ -69,11 +69,11 @@ Promises::Deferred->new->reject("bar")->then(
         "foo";
     }
 )->then(
-    sub { fail("This should never be called") },
     sub {
         my $result = shift;
-        is($result, "foo", "... chained-reject foo");
-    }
+        is($result, "foo", "... error handler returns foo");
+    },
+    sub { fail("This should never be called, previous error handler returned value") },
 );
 
 done_testing;

--- a/t/050-wrap-error-args.t
+++ b/t/050-wrap-error-args.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Promises 'when';
 use Test::More 0.89;
-use Test::Fatal;
+use Test::Exception;
 
 sub do_it {
     my $d = Promises::Deferred->new;
@@ -12,25 +12,29 @@ sub do_it {
 }
 
 {
-    my $e = exception {
-        do_it->then(
+    my $p;
+    lives_ok {
+        $p = do_it->then(
             sub { die { success => \@_ } },
             sub { die { fail    => \@_ } },
         );
-    };
+    } "Exception was handled";
 
-    is_deeply $e, { fail => ['fail'] };
+    is $p->status, Promises::Deferred->REJECTED, "Promise was rejected";
+    is_deeply $p->result, [{ fail => ['fail'] }];
 }
 
 {
-    my $e = exception {
-        when(do_it)->then(
+    my $p;
+    lives_ok {
+        $p = when(do_it)->then(
             sub { die { success => \@_ } },
             sub { die { fail    => \@_ } },
         );
-    };
+    } "Exception was handled";
 
-    is_deeply $e, { fail => ['fail'] };
+    is $p->status, Promises::Deferred->REJECTED, "Promise was rejected";
+    is_deeply $p->result, [{ fail => ['fail'] }];
 }
 
 done_testing;


### PR DESCRIPTION
- even onFulfilled handler can be undef
- exceptions thrown in onFulfilled an onRejected handlers (args of then) are caught
- resolve and reject method prevented to be called more than once
- if onRejected handler returns value (does not throw exception) the promise is fulfilled
- intermediate states (REJECTING, RESOLVING) dropped
- the promise of deferred object is not a property, but is created on the fly
  ( to prevent circular reference)
