### PR TITLE
Allow then() to execute in the context of the event loop.

### DIFF
--- a/lib/Promises/Deferred/AE.pm
+++ b/lib/Promises/Deferred/AE.pm
@@ -1,0 +1,19 @@
+package Promises::Deferred::AE;
+
+use strict;
+use warnings;
+use AE;
+use Promises::Deferred;
+our @ISA = qw(Promises::Deferred);
+
+sub _notify {
+    my ( $self, $callbacks, $result ) = @_;
+    foreach my $cb (@$callbacks) {
+        AE::postpone { $cb->(@$result) };
+    }
+    $self->{'resolved'} = [];
+    $self->{'rejected'} = [];
+
+}
+
+1;


### PR DESCRIPTION
The native Promises::Deferred implementation can result in deep
recursion when there are many chained then() callbacks.
Instead, each callback can be executed in the event loop context,
avoiding deep recursion.

This commit adds an implementation for AnyEvent and can be used as:

```
use Promises backend => ['AE'], qw(deferred collect);
```

First attempt at fixing #8
