### PR TITLE
Make the deferred backend a package variable

### DIFF
--- a/lib/Promises/Deferred/AE.pm
+++ b/lib/Promises/Deferred/AE.pm
@@ -37,5 +37,18 @@ given to C<then> should be run asynchronously (meaning in the
 next turn of the event loop), this module provides support for
 doing so using the L<AE> module.
 
+Module authors should not care which event loop will be used but
+instead should just the Promises module directly:
+
+    package MyClass;
+
+    use Promises qw(deferred collect);
+
+End users of the module can specify which backend to use at the start of
+the application:
+
+    use Promises -backend => ['AE'];
+    use MyClass;
+
 =back
 

--- a/lib/Promises/Deferred/AnyEvent.pm
+++ b/lib/Promises/Deferred/AnyEvent.pm
@@ -37,5 +37,18 @@ given to C<then> should be run asynchronously (meaning in the
 next turn of the event loop), this module provides support for
 doing so using the L<AnyEvent> module.
 
+Module authors should not care which event loop will be used but
+instead should just the Promises module directly:
+
+    package MyClass;
+
+    use Promises qw(deferred collect);
+
+End users of the module can specify which backend to use at the start of
+the application:
+
+    use Promises -backend => ['AnyEvent'];
+    use MyClass;
+
 =back
 

--- a/lib/Promises/Deferred/EV.pm
+++ b/lib/Promises/Deferred/EV.pm
@@ -40,5 +40,18 @@ given to C<then> should be run asynchronously (meaning in the
 next turn of the event loop), this module provides support for
 doing so using the L<EV> module.
 
+Module authors should not care which event loop will be used but
+instead should just the Promises module directly:
+
+    package MyClass;
+
+    use Promises qw(deferred collect);
+
+End users of the module can specify which backend to use at the start of
+the application:
+
+    use Promises -backend => ['EV'];
+    use MyClass;
+
 =back
 


### PR DESCRIPTION
Module authors should not care which event loop is in use. They should
just use the Promises module directly:

```
package MyClass;
use Promises qw(deferred collect)
```

The end use should specify their preferred event loop once at the start
of their application:

```
use Promises -backend => ['AE'];
use MyClass;
```

See #8
