### PR TITLE
Added Mojo::IOLoop deferred backend

### DIFF
--- a/lib/Promises.pm
+++ b/lib/Promises.pm
@@ -178,6 +178,8 @@ See:
 
 =item * L<Promises::Deferred::EV>
 
+=item * L<Promises::Deferred::Mojo>
+
 =back
 
 =head2 Relation to Promises/Futures in Scala

--- a/lib/Promises/Deferred/Mojo.pm
+++ b/lib/Promises/Deferred/Mojo.pm
@@ -1,0 +1,57 @@
+package Promises::Deferred::Mojo;
+# ABSTRACT: An implementation of Promises in Perl
+
+use strict;
+use warnings;
+
+use Mojo::IOLoop;
+
+use parent 'Promises::Deferred';
+
+sub _notify {
+    my ( $self, $callbacks, $result ) = @_;
+    Mojo::IOLoop->timer(0,sub {
+        foreach my $cb (@$callbacks) {
+            $cb->(@$result);
+        }
+    });
+    $self->{'resolved'} = [];
+    $self->{'rejected'} = [];
+
+}
+
+1;
+
+__END__
+
+=head1 SYNOPSIS
+
+    use Promises backend => ['Mojo'], qw[ deferred collect ];
+
+    # ... everything else is the same
+
+=head1 DESCRIPTION
+
+The "Promise/A+" spec strongly suggests that the callbacks
+given to C<then> should be run asynchronously (meaning in the
+next turn of the event loop), this module provides support for
+doing so using the L<Mojo::IOLoop> module.
+
+Module authors should not care which event loop will be used but
+instead should just the Promises module directly:
+
+    package MyClass;
+
+    use Promises qw(deferred collect);
+
+End users of the module can specify which backend to use at the start of
+the application:
+
+    use Promises -backend => ['Mojo'];
+    use MyClass;
+
+B<Note:> If you are using Mojolicious with the L<EV> event loop, then you
+should use the L<Promises::Deferred::EV> backend instead.
+
+=back
+

--- a/t/034-deferred-Mojo.t
+++ b/t/034-deferred-Mojo.t
@@ -1,0 +1,25 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Mojo::IOLoop;;
+
+use Promises backend => ['Mojo'], 'deferred';
+
+my $run = 0;
+
+my $d = deferred;
+$d->then( sub { $run++ });
+$d->resolve;
+
+is($run, 0, '... not run synchronously');
+
+Mojo::IOLoop->one_tick;
+
+is($run, 1, '... run asynchronously');
+
+done_testing;
+


### PR DESCRIPTION
Mojolicious will use the EV event loop if it is available, but will fall back to to Mojo::IOLoop if not.  This commit adds support for Mojo::IOLoop.
