### PR TITLE
Don't localize $@ in Perl < v5.14 as it caused $@ to be clobbered.

### DIFF
--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -7,6 +7,15 @@ use warnings;
 use Scalar::Util qw[ blessed reftype ];
 use Carp         qw[ confess ];
 
+BEGIN {
+    if ( $^V lt "v5.14" ) {
+        eval "sub LOCALISE_EXCEPTIONS () {0}";
+    }
+    else {
+        eval "sub LOCALISE_EXCEPTIONS () {1}";
+    }
+}
+
 use Promises::Promise;
 
 use constant IN_PROGRESS => 'in progress';
@@ -120,7 +129,7 @@ sub finalize {
 sub _wrap {
     my ($self, $d, $f, $method) = @_;
     return sub {
-        local $@;
+        LOCALISE_EXCEPTIONS && local $@;
         my @results = do { $f->( @_ ) };
         if ($@) {
             $d->reject( $@ );


### PR DESCRIPTION
See https://metacpan.org/pod/release/RJBS/perl-5.18.2/pod/perl5140delta.pod#Exception-Handling

Fixes #14

Not sure if this is the  right way to compare versions, and the string eval feels hackish but I don't see any other way to do the conditional localization.
