### PR TITLE
Localized exceptions still failing in perl < 5.14 if the

### DIFF
--- a/t/050-exceptions-pp.t
+++ b/t/050-exceptions-pp.t
@@ -10,6 +10,12 @@ use Test::More;
 use Test::Fatal;
 
 BEGIN {
+    if ( $^V lt 5.14 ) {
+        plan skip_all =>
+            'Localizing $@ before Perl 5.14 clobbers the exception';
+        done_testing;
+        exit;
+    }
     use_ok 'Promises::Deferred';
 }
 


### PR DESCRIPTION
pureperl deferred backend in use.  The choice here is
between not localizing at all and having the user choose
a Deferred backend. I think this is the better choice
so have skipped the PP exception tests on < 5.14
