### PR TITLE
A single pre-resolved promise passed to collect fails

### DIFF
--- a/lib/Promises.pm
+++ b/lib/Promises.pm
@@ -10,7 +10,7 @@ our $Backend = 'Promises::Deferred';
 
 use Sub::Exporter -setup => {
     collectors => [ 'backend' => \'_set_backend' ],
-    exports    => [ qw[ deferred collect ]]
+    exports    => [qw[ deferred collect ]]
 };
 
 sub _set_backend {
@@ -34,7 +34,6 @@ sub collect {
     my $all_done  = $Backend->new;
     my $results   = [];
     my $remaining = scalar @promises;
-
     foreach my $i ( 0 .. $#promises ) {
         my $p = $promises[$i];
         $p->then(
@@ -51,7 +50,8 @@ sub collect {
         );
     }
 
-    $all_done->resolve(@$results) if $remaining == 0;
+    $all_done->resolve(@$results)
+        if $remaining == 0 and $all_done->is_in_progress;
 
     $all_done->promise;
 }

--- a/t/010-collect.t
+++ b/t/010-collect.t
@@ -10,7 +10,7 @@ use AnyEvent;
 use AsyncUtil qw[ delay_me ];
 
 BEGIN {
-    use_ok('Promises', 'collect');
+    use_ok( 'Promises', 'collect', 'deferred' );
 }
 
 my $cv = AnyEvent->condvar;
@@ -39,5 +39,17 @@ is_deeply(
 
 is( $p0->status, Promises::Deferred->RESOLVED, '... got the right status in promise 0' );
 is( $p1->status, Promises::Deferred->RESOLVED, '... got the right status in promise 1' );
+
+$p0 = collect( deferred->resolve('foo')->promise )->then(
+    sub {
+        is shift()->[0], 'foo', 'Presolved collect';
+    }
+);
+
+$p0 = collect( deferred->reject('foo')->promise )->catch(
+    sub {
+        is shift(), 'foo', 'Prerejected collect';
+    }
+);
 
 done_testing;


### PR DESCRIPTION
because $all_done is already resolved.

Check if $all_done is still in progress before resolving. Tests added.

Fixes #28
