### PR TITLE
Make Mojo::IOLoop recommended instead of required.

### DIFF
--- a/t/053-exceptions-mojo.t
+++ b/t/053-exceptions-mojo.t
@@ -9,6 +9,9 @@ use Test::More;
 use Test::Fatal;
 
 BEGIN {
+    if (!eval { require Mojo::IOLoop; Mojo::IOLoop->import; 1 }) {
+        plan skip_all => "Mojo::IOLoop is required for this test";
+    }
     use_ok 'Promises::Deferred::Mojo';
 }
 


### PR DESCRIPTION
Mojolicious requires Perl 5.10, while Promises with AnyEvent works on Perl 5.8.

This PR allows the test suite to run on Perl 5.8.9 when Mojo::IOLoop is not installed.  Also needs the META file to be updated.

Would appreciate a new release soon as this is all that is blocking my async Elasticsearch release.

thanks stevan
