### PR TITLE
The test suite requires EV.pm to be present, added it to dist.ini's

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,3 +33,4 @@ Sub::Exporter         = 0
 [Prereqs / TestRequires]
 Test::More            = 0.88
 AnyEvent              = 0
+EV                    = 0


### PR DESCRIPTION
TestRequires section. Currently, when I'm installing Promises via cpanm, I get

 # Failed test 'use Promises::Deferred::EV;'
 # at t/052-exceptions-ev-anyevent.t line 12.
 # Tried to use 'Promises::Deferred::EV'.
 # Error: Can't locate EV.pm in @INC (you may need to install the EV module) (@INC contains: t/lib    /home/mschilli/.cpanm/work/1413273423.4595/Promises-0.93/blib/lib /home/mschilli/.cpanm/work/1413273423.4595/Promises-0.93/blib/arch /h

Thanks for this great module!
