### PR TITLE
stab at warnings on unhandled rejects

### DIFF
--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -156,6 +156,8 @@ sub _notify {
 
     my $cbs = $self->is_resolved ? $self->{resolved} : $self->{rejected};
 
+    $self->{handled_reject} = 1 if $self->is_rejected && @$cbs;
+
     $self->{'resolved'} = [];
     $self->{'rejected'} = [];
 
@@ -175,6 +177,14 @@ sub _callable_or_undef {
             ? $_
             : undef
     } @_;
+}
+
+sub DESTROY {
+    my ($self) = @_;
+    use Data::Dumper::Concise;
+    use Carp qw(cluck);
+    cluck( "not handled rejection: ". Dumper($self->result) )
+        if $self->is_rejected && $self->{handled_reject};
 }
 
 1;

--- a/tttt.pl
+++ b/tttt.pl
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+use v5.16;
+
+use AnyEvent;
+use Promises backend => ['AnyEvent'];
+use Promises qw(deferred);
+
+
+my $cv = AnyEvent->condvar;
+my $d = deferred();
+#$d->then(sub {die "boo"})->then(sub {print STDERR "wtf\n"; $cv->send }, sub { print STDERR "rejected\n"; });
+$d->then(sub {die "boo"})->then(sub {print STDERR "wtf\n"; $cv->send });
+$d->resolve("xxx");
+
+$cv->recv;


### PR DESCRIPTION
Hi,

This is a stab to check ground. I often find myself spending some time looking for exception I forgot to handle. Mostly during prototyping and because of mistake (unexpected runtime exception) in a resolve callback. I find such a warning very helpful.

Do you see place in the master for something like this? If not I will just monkey patch.
