### PR TITLE
Issue in 5.24.0 with Moose Object use overload and meta->superclasses

### DIFF
--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -137,7 +137,7 @@ sub _wrap {
             @results = do { $f->(@_) };
             1;
         }
-            || do { $error = $@ || 'Unknown reason' };
+            || do { $error = $@ // 'Unknown reason' };
 
         if ($error) {
             $d->reject($error);


### PR DESCRIPTION
Hi,
I am testing out 5.24.0 and I have got some strange behaviour.  When certain exceptions are thrown within  '_wrap' ed code, the error is lost.

Specifically it appears that within the do {} block after the eval in _wrap, the || operator is doing something weird.
$error = $@ || 'Unknown reason' results in $error = undef.

It does this for a particular class of things passed to die.  These seems to be Moose objects where meta->superclasses has been called.

$error = $@ // 'Unknown reason' doesn't seem to exhibit the same behaviour though.  

Admittedly this will change behaviour for falsely values sent to die. Not sure how much of an issue this is.

I have attached two test files showing the issue.  error.pl.txt where // is used amd noerror.pl.txt where the error is lost.

This doesn't seem to be an issue with the module specifically, but does cause an issue using this module with perl 5.24.0 and the fix is quite simple.  If you can replicate the issue, where else should I report it?

Thanks in advance

[error.pl.txt](https://github.com/stevan/promises-perl/files/557851/error.pl.txt)
[noerror.pl.txt](https://github.com/stevan/promises-perl/files/557852/noerror.pl.txt)
