### PR TITLE
Optimize Promises performance

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Perl extension Promises
 
 {NEXT}
   - doc fix from Amelia Ireland (RT#107559)
+  - Rewrote the code for performance
+  - Calling die() from done() is now safe
 
 0.94 Monday, December 29, 2014
   - fixing the other side of the AutoPrereqs 

--- a/lib/Promises/Cookbook/GentleIntro.pod
+++ b/lib/Promises/Cookbook/GentleIntro.pod
@@ -555,21 +555,8 @@ L<Tail Call optimization|http://en.wikipedia.org/wiki/Tail_call> to
 keep the return stack flat, but we don't have this option.
 
 Instead, we have the C<done()> method which, like C<then()>, accepts a I<resolved> callback
-and a I<rejected> callback. But it differs from C<then()> in two ways:
-
-=over
-
-=item *
-
-It doesn't return a promise, which means that the chain ends with the C<done()> step.
-
-=item *
-
-Callbacks are not run in an C<eval> block, so calling C<die()> will throw a
-fatal exception. (Most event loops, however will catch the exception, warn,
-and continue running.)
-
-=back
+and a I<rejected> callback. But it differs from C<then()> in one way: it doesn't return
+a promise, which means that the chain ends with the C<done()> step.
 
 The code can be rewritten using C<done()> instead of C<then()> and an event
 loop specific backend, and it will happily process millions of lines without

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -203,15 +203,15 @@ sub reject {
 
 sub finally {
     my ($self, $sub) = @_;
-    my ($ok, @result);
+    my (@result);
     my $finally = sub {
-        return ($ok ? Promises::resolved(@result) : Promises::rejected(@result));
+        return @result;
     };
     return $self->then(sub {
-        $ok = 1; @result = @_;
+        @result = @_;
         goto &$sub;
     }, sub {
-        $ok = 0; @result = @_;
+        @result = Promises::rejected(@_);
         goto &$sub;
     })->then($finally, $finally);
 }

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -28,7 +28,9 @@ sub _set_backend {
         $backend = 'Promises::Deferred::' . $backend;
     }
 
-    eval "use $backend; 1;" or return;
+    require Module::Runtime;
+    Module::Runtime::use_module($backend) || return;
+
     $notify_sub= $backend->get_notify_sub;
 }
 

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -133,6 +133,7 @@ sub _chain_promise {
         $target->{state} = $source->{state};
         $target->{result} = $source->{result};
         _invoke_cbs(delete $target->{cb});
+        $target->_handle_chain if $target->{chained_promises};
     } else {
         push @{$source->{chained_promises} ||= []}, $target;
     }

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -146,14 +146,16 @@ sub _handle_chain {
     my ($state, $result) = @$self{qw/state result/};
 
     my @todo = @{delete $self->{chained_promises}};
+    my @cbs;
     while (my $promise = shift @todo) {
         $promise->{state} = $state;
         $promise->{result} = $result;
-        _invoke_cbs(delete $promise->{cb});
         if (my $chain = delete $promise->{chained_promises}) {
             push @todo, @$chain;
         }
+        push @cbs, @{ delete $promise->{cb} };
     }
+    _invoke_cbs(\@cbs) if @cbs;
     return;
 }
 

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -87,6 +87,7 @@ sub _invoke_cb {
     my $self = shift @$cb;
 
     if (my $invoke_callback = $cb->[$self->{state}]) {
+        local $@;
         eval {
             my @result = $invoke_callback->(@{$self->{result}});
             if (my $next = $cb->[0]) {

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -44,11 +44,16 @@ sub _invoke_cbs_callback {
 }
 
 sub new {
-    return bless \{cb=>[], state=>0}, __PACKAGE__;
+    my ($class)= @_;
+    return bless \{
+        cb => [],
+        state => 0,
+        result => undef,
+    }, $class;
 }
 
 sub deferred (;&) {
-    my $self= new();
+    my $self= __PACKAGE__->new();
     if (my $code= shift) {
         $self->resolve;
         return $self->then(sub{
@@ -135,7 +140,7 @@ sub _replace_promise {
 
 sub then {
     my ($self, $ok, $nope)= @_;
-    my $then= defined(wantarray) ? new : undef;
+    my $then= defined(wantarray) ? __PACKAGE__->new() : undef;
 
     my $cb_arr= [ $self, $then, $ok, $nope ];
     if ($$self->{state}) {
@@ -202,7 +207,7 @@ sub is_fulfilled   { ${$_[0]}->{state} == 1 }
 sub is_failed      { ${$_[0]}->{state} == 2 }
 
 sub result         { ${$_[0]}->{result} }
-sub promise        { bless \$_[0], 'Promises::Promise' }
+sub promise        { Promises::Promise->_new($_[0]) }
 
 
 1;

--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -94,6 +94,7 @@ sub _invoke_cb {
 
     if (my $invoke_callback = $cb->[$self->{state}]) {
         local $@;
+        local $_;
         eval {
             my (@result, $ret);
             {

--- a/lib/Promises/Deferred/AnyEvent.pm
+++ b/lib/Promises/Deferred/AnyEvent.pm
@@ -6,15 +6,16 @@ use warnings;
 
 use AnyEvent;
 
-use parent 'Promises::Deferred';
+sub notify_callback {
+    Promises::Deferred::_invoke_cbs_callback();
+}
 
-sub _notify_backend {
-    my ( $self, $callbacks, $result ) = @_;
-    AnyEvent::postpone {
-        foreach my $cb (@$callbacks) {
-            $cb->(@$result);
-        }
-    };
+sub do_notify {
+    AE::postpone \&notify_callback;
+}
+
+sub get_notify_sub {
+    return \&do_notify;
 }
 
 1;

--- a/lib/Promises/Deferred/Default.pm
+++ b/lib/Promises/Deferred/Default.pm
@@ -1,17 +1,11 @@
-package Promises::Deferred::AE;
+package Promises::Deferred::Default;
 # ABSTRACT: An implementation of Promises in Perl
 
 use strict;
 use warnings;
 
-use AE;
-
-sub notify_callback {
-    Promises::Deferred::_invoke_cbs_callback();
-}
-
 sub do_notify {
-    AE::postpone \&notify_callback;
+    Promises::Deferred::_invoke_cbs_callback();
 }
 
 sub get_notify_sub {
@@ -24,7 +18,7 @@ __END__
 
 =head1 SYNOPSIS
 
-    use Promises backend => ['AE'], qw[ deferred collect ];
+    use Promises backend => ['Default'], qw[ deferred collect ];
 
     # ... everything else is the same
 
@@ -32,8 +26,8 @@ __END__
 
 The "Promise/A+" spec strongly suggests that the callbacks
 given to C<then> should be run asynchronously (meaning in the
-next turn of the event loop), this module provides support for
-doing so using the L<AE> module.
+next turn of the event loop), this module provides support for running
+without an event loop (not recommended, but still the default).
 
 Module authors should not care which event loop will be used but
 instead should just the Promises module directly:
@@ -45,7 +39,7 @@ instead should just the Promises module directly:
 End users of the module can specify which backend to use at the start of
 the application:
 
-    use Promises -backend => ['AE'];
+    use Promises -backend => ['Default'];
     use MyClass;
 
 =cut

--- a/lib/Promises/Deferred/EV.pm
+++ b/lib/Promises/Deferred/EV.pm
@@ -6,17 +6,15 @@ use warnings;
 
 use EV;
 
-use parent 'Promises::Deferred';
-
-sub _notify_backend {
-    my ( $self, $callbacks, $result ) = @_;
-
+sub do_notify {
     my $w; $w = EV::timer( 0, 0, sub {
-        foreach my $cb (@$callbacks) {
-            $cb->(@$result);
-        }
+        Promises::Deferred::_invoke_cbs_callback();
         undef $w;
     });
+}
+
+sub get_notify_sub {
+    return \&do_notify;
 }
 
 1;

--- a/lib/Promises/Deferred/Mojo.pm
+++ b/lib/Promises/Deferred/Mojo.pm
@@ -6,15 +6,16 @@ use warnings;
 
 use Mojo::IOLoop;
 
-use parent 'Promises::Deferred';
+sub notify_callback {
+    Promises::Deferred::_invoke_cbs_callback();
+}
 
-sub _notify_backend {
-    my ( $self, $callbacks, $result ) = @_;
-    Mojo::IOLoop->timer(0,sub {
-        foreach my $cb (@$callbacks) {
-            $cb->(@$result);
-        }
-    });
+sub do_notify {
+    Mojo::IOLoop->timer(0, \&notify_callback);
+}
+
+sub get_notify_sub {
+    return \&do_notify;
 }
 
 1;

--- a/lib/Promises/Promise.pm
+++ b/lib/Promises/Promise.pm
@@ -5,6 +5,11 @@ package Promises::Promise;
 use strict;
 use warnings;
 
+sub _new {
+    my ($class, $deferred)= @_;
+    return bless \$deferred, $class;
+}
+
 sub then    { ${shift()}->then(@_) }
 sub chain   { ${shift()}->chain(@_) }
 sub catch   { ${shift()}->catch(@_) }

--- a/lib/Promises/Promise.pm
+++ b/lib/Promises/Promise.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 sub _new {
-    my ($class, $deferred)= @_;
+    my ($class, $deferred) = @_;
     return bless \$deferred, $class;
 }
 

--- a/lib/Promises/Promise.pm
+++ b/lib/Promises/Promise.pm
@@ -5,32 +5,22 @@ package Promises::Promise;
 use strict;
 use warnings;
 
-use Scalar::Util qw[ blessed ];
-use Carp qw[ confess ];
+sub then    { ${shift()}->then(@_) }
+sub chain   { ${shift()}->chain(@_) }
+sub catch   { ${shift()}->catch(@_) }
+sub done    { ${shift()}->done(@_) }
+sub finally { ${shift()}->finally(@_) }
+sub status  { ${shift()}->status }
+sub result  { ${shift()}->result }
 
-sub new {
-    my ( $class, $deferred ) = @_;
-    ( blessed $deferred && $deferred->isa('Promises::Deferred') )
-        || confess "You must supply an instance of Promises::Deferred";
-    bless { 'deferred' => $deferred } => $class;
-}
+sub is_unfulfilled { ${shift()}->is_unfulfilled }
+sub is_fulfilled   { ${shift()}->is_fulfilled }
+sub is_failed      { ${shift()}->is_failed }
+sub is_done        { ${shift()}->is_done }
 
-sub then    { (shift)->{'deferred'}->then(@_) }
-sub chain   { (shift)->{'deferred'}->chain(@_) }
-sub catch   { (shift)->{'deferred'}->catch(@_) }
-sub done    { (shift)->{'deferred'}->done(@_) }
-sub finally { (shift)->{'deferred'}->finally(@_) }
-sub status  { (shift)->{'deferred'}->status }
-sub result  { (shift)->{'deferred'}->result }
-
-sub is_unfulfilled { (shift)->{'deferred'}->is_unfulfilled }
-sub is_fulfilled   { (shift)->{'deferred'}->is_fulfilled }
-sub is_failed      { (shift)->{'deferred'}->is_failed }
-sub is_done        { (shift)->{'deferred'}->is_done }
-
-sub is_in_progress { (shift)->{'deferred'}->is_in_progress }
-sub is_resolved    { (shift)->{'deferred'}->is_resolved }
-sub is_rejected    { (shift)->{'deferred'}->is_rejected }
+sub is_in_progress { ${shift()}->is_in_progress }
+sub is_resolved    { ${shift()}->is_resolved }
+sub is_rejected    { ${shift()}->is_rejected }
 
 1;
 
@@ -54,12 +44,6 @@ are meant to work together.
 =head1 METHODS
 
 =over 4
-
-=item C<new( $deferred )>
-
-The constructor only takes one parameter and that is an
-instance of L<Promises::Deferred> that you want this
-object to proxy.
 
 =item C<then( $callback, $error )>
 
@@ -118,4 +102,3 @@ This calls C<is_rejected> on the proxied L<Promises::Deferred> instance.
 This calls C<is_done> on the proxied L<Promises::Deferred> instance.
 
 =back
-

--- a/t/050-exceptions-pp.t
+++ b/t/050-exceptions-pp.t
@@ -19,6 +19,7 @@ BEGIN {
         exit;
     }
     use_ok 'Promises::Deferred';
+    use Promises 'deferred';
 }
 
 my @out;
@@ -60,8 +61,8 @@ is( exception {
         my $w = AE::timer( 1, 0, sub { $cv->send } );
         $cv->recv;
     },
-    "Final\n",
-    "Exception in PP done dies"
+    undef,
+    "Exception in PP done is swallowed"
 );
 
 is $out[0], '1: OK',   "Resolve";
@@ -73,7 +74,7 @@ is $out[4], "5: OK\n", "Reject then die";
 #===================================
 sub a_promise {
 #===================================
-    my $d = Promises::Deferred->new;
+    my $d = deferred;
     my $w;
     $w = AnyEvent->timer(
         after => 0,

--- a/t/051-exceptions-pp-anyevent.t
+++ b/t/051-exceptions-pp-anyevent.t
@@ -55,8 +55,8 @@ is( exception {
         my $w = AE::timer( 1, 0, sub { $cv->send } );
         $cv->recv;
     },
-    "Final\n",
-    "Exception in AnyEvent PP done dies"
+    undef,
+    "Exception in AnyEvent PP is swallowed"
 );
 
 is $out[0], '1: OK',   "Resolve";

--- a/t/051-exceptions-pp-anyevent.t
+++ b/t/051-exceptions-pp-anyevent.t
@@ -13,6 +13,7 @@ BEGIN {
         plan skip_all => "AnyEvent is required for this test";
     }
     use_ok 'Promises::Deferred::AnyEvent';
+    use Promises 'deferred', backend => ['AnyEvent'];
 }
 
 my @out;
@@ -68,7 +69,7 @@ is $out[4], "5: OK\n", "Reject then die";
 #===================================
 sub a_promise {
 #===================================
-    my $d = Promises::Deferred::AnyEvent->new;
+    my $d = deferred;
     my $w;
     $w = AnyEvent->timer(
         after => 0,

--- a/t/052-exceptions-ev-anyevent.t
+++ b/t/052-exceptions-ev-anyevent.t
@@ -12,6 +12,7 @@ BEGIN {
         plan skip_all => "AnyEvent/EV is required for this test";
     }
     use_ok 'Promises::Deferred::EV';
+    use Promises 'deferred', backend => ['EV'];
 }
 
 my @out;
@@ -66,7 +67,7 @@ is $out[4], "5: OK\n", "Reject then die";
 #===================================
 sub a_promise {
 #===================================
-    my $d = Promises::Deferred::EV->new;
+    my $d = deferred;
     my $w;
     $w = AnyEvent->timer(
         after => 0,

--- a/t/053-exceptions-mojo.t
+++ b/t/053-exceptions-mojo.t
@@ -13,6 +13,7 @@ BEGIN {
         plan skip_all => "Mojo::IOLoop is required for this test";
     }
     use_ok 'Promises::Deferred::Mojo';
+    use Promises qw/deferred/, backend => ["Mojo"];
 }
 
 my @out;
@@ -66,7 +67,7 @@ is $out[4], "5: OK\n", "Reject then die";
 #===================================
 sub a_promise {
 #===================================
-    my $d = Promises::Deferred::Mojo->new;
+    my $d = deferred;
     Mojo::IOLoop->timer( 0, sub { $d->resolve('OK') } );
     $d->promise;
 }


### PR DESCRIPTION
Hi Stevan,

I've optimized Promises for performance. Here's the pull request (updated a bit after your comments on #60). It's almost backwards compatible, but I've made the `done()` function safe (according to the docs it was unsafe with known bad side-effects) and updated docs accordingly. According to a search through all CPAN modules using Promises, this behavior was not used anywhere but the Promises tests.

Quick benchmark : 
```
# OLD
Benchmark: running one, two for at least 10 CPU seconds...
       one: 10 wallclock secs (10.42 usr +  0.00 sys = 10.42 CPU) @ 8939.35/s (n=93148)
       two: 11 wallclock secs (10.89 usr +  0.00 sys = 10.89 CPU) @ 3057.21/s (n=33293)

# NEW
Benchmark: running one, two for at least 10 CPU seconds...
       one: 11 wallclock secs (10.59 usr +  0.00 sys = 10.59 CPU) @ 28733.81/s (n=304291)
       two: 10 wallclock secs (10.09 usr +  0.00 sys = 10.09 CPU) @ 10273.84/s (n=103663)
```

And of course the corresponding code : 
```
use v5.18;
use warnings;
use Benchmark qw/timethese/;
use Promises qw/collect deferred/;

sub a_promise {
    my $deferred= deferred;
    $deferred->resolve(1,2,3,4,5);
    return $deferred->promise;
}

timethese(-10, {
    one => sub {
        my $have_result;
        a_promise()->then(sub { a_promise(); })->then(sub { $have_result= 1; });
        die unless $have_result;
    },
    two => sub {
        my $i;
        a_promise()->then(sub {
            if (++$i == 5) {
                return;
            } else {
                a_promise()->then(__SUB__);
            }
        });
        die unless $i == 5;
    },
});
```