### PR TITLE
Load AnyEvent, otherwise the reference to AE::cv fails

### DIFF
--- a/t/052-exceptions-ev-anyevent.t
+++ b/t/052-exceptions-ev-anyevent.t
@@ -8,6 +8,7 @@ use Test::More;
 use Test::Fatal;
 
 use Test::Requires 'EV';
+use Test::Requires 'AnyEvent';
 
 use Promises 'deferred', backend => ['EV'];
 


### PR DESCRIPTION
Running "dzil test" on origin/master fails currently, because t/052-exceptions-ev-anyevent.t references AE::cv, but AnyEvent/AE hasn't been use'd.