### PR TITLE
Fixes for  warn_on_unhandled_reject

### DIFF
--- a/lib/Promises.pm
+++ b/lib/Promises.pm
@@ -47,7 +47,7 @@ sub _set_warn_on_unhandled_reject {
 
             warn "Promise's rejection ", $dump,
                 " was not handled",
-                ( ' at ', join ' line ', @{$self->{_caller}} ) x !! $self->{_caller}, "\n";
+                ($self->{_caller} ? ( ' at ', join ' line ', @{$self->{_caller}} ) : ()) , "\n";
         };
     }
 }

--- a/lib/Promises.pm
+++ b/lib/Promises.pm
@@ -43,7 +43,7 @@ sub _set_warn_on_unhandled_reject {
                 Data::Dumper->new([$self->result])->Terse(1)->Dump;
 
             chomp $dump;
-            $dump =~ s/\n/ /g;
+            $dump =~ s/\n\s*/ /g;
 
             warn "Promise's rejection ", $dump,
                 " was not handled",

--- a/t/late-warning.t
+++ b/t/late-warning.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Warn;
+
+use Promises qw(deferred);
+
+warning_like {
+    my $d = deferred();
+    $d->then(sub {die "boo"})->then(sub { 'stuff' });
+    # Simulate run-time requiring a package use-ing warn_on_unhandled_reject
+    Promises->import('warn_on_unhandled_reject' => [1]);
+    $d->resolve;
+} qr!Promise's rejection.*boo.*at t/late-warning.t line 11!s, "catch a die";
+
+
+done_testing;

--- a/t/warnings.t
+++ b/t/warnings.t
@@ -18,5 +18,11 @@ warning_like {
     $d->reject(1,2,3);
 } qr!Promise's rejection.*line 17!s, "catch regular reject";
 
+warning_like {
+    my $d = deferred();
+    $d->then(sub { "boo"})->then(sub { 'stuff' });
+    $d->reject(1,2,3);
+} qr!Promise's rejection \[ 1, 2, 3 \].*line 23!s, "nicely formatted single-line rejection dump";
+
 
 done_testing;


### PR DESCRIPTION
One commit fixes #76.

Another (less important) commit turns a dump of the perl value `[1,2,3]` into the string 

    [ 1, 2, 3 ]

instead of the string

    [   1,   2,   3 ]

(the superfluous whitespace is removed).