### PR TITLE
In similar vain to PR #61, optimize _notify_backend (for IO::Async)

### DIFF
--- a/lib/Promises/Deferred/IO/Async.pm
+++ b/lib/Promises/Deferred/IO/Async.pm
@@ -11,13 +11,26 @@ use parent 'Promises::Deferred';
 
 our $Loop = IO::Async::Loop->new;
 
+# Before the 'later'-based approach used below, there was an
+# Async::IO::Timer::Countdown based approach for _notify_backend.
+# The current code is much more performant:
+
+# Original code
+# Backend:  Promises::Deferred::IO::Async
+# Benchmark: running one, two for at least 10 CPU seconds...
+#        one: 41 wallclock secs @ 815.48/s (n=8954)
+#        two: 31 wallclock secs @ 373.39/s (n=3760)
+
+# New approach:
+# Backend:  Promises::Deferred::IO::Async
+# Benchmark: running one, two for at least 10 CPU seconds...
+#        one: 11 wallclock secs @ 8436.69/s (n=88754)
+#        two: 10 wallclock secs @ 3150.85/s (n=33273)
+
+
 sub _notify_backend {
     my ( $self, $callbacks, $result ) = @_;
-    $Loop->add(
-        IO::Async::Timer::Countdown->new( delay => 0, on_expire => sub {
-            $_->(@$result) for @$callbacks;
-        })->start
-    );
+    $Loop->later(sub { $_->(@$result) for @$callbacks; });
 }
 
 sub _timeout {


### PR DESCRIPTION
@yanick turns out there was another 10-fold performance optimization possible, for the IO::Async::Loop::EV backend, to be exact.