### PR TITLE
Abort using confess instead of die

### DIFF
--- a/lib/Promises/Deferred.pm
+++ b/lib/Promises/Deferred.pm
@@ -55,7 +55,7 @@ sub is_failed      { $_[0]->is_rejected }
 sub resolve {
     my $self = shift;
 
-    die "Cannot resolve. Already  " . $self->status
+    confess "Cannot resolve. Already " . $self->status
         unless $self->is_in_progress;
 
     $self->{'result'} = [@_];
@@ -66,7 +66,7 @@ sub resolve {
 
 sub reject {
     my $self = shift;
-    die "Cannot reject. Already  " . $self->status
+    confess "Cannot reject. Already " . $self->status
         unless $self->is_in_progress;
 
     $self->{'result'} = [@_];


### PR DESCRIPTION
This makes debugging in async environments much easier compared to simple die.

Currently the error message when an already rejected/resolved promise was rejected/resolved again is not very helpful finding the cause (since the exception goes all the way up into the AnyEvent loop and is re-thrown at the condvar recv